### PR TITLE
Allow changing of voting mint config parameters

### DIFF
--- a/programs/voter-stake-registry/src/error.rs
+++ b/programs/voter-stake-registry/src/error.rs
@@ -58,4 +58,6 @@ pub enum ErrorCode {
     VoterWeightOverflow,
     #[msg("")]
     LockupSaturationMustBePositive,
+    #[msg("")]
+    VotingMintConfiguredWithDifferentIndex,
 }

--- a/programs/voter-stake-registry/tests/test_basic.rs
+++ b/programs/voter-stake-registry/tests/test_basic.rs
@@ -33,6 +33,21 @@ async fn test_basic() -> Result<(), TransportError> {
         .addin
         .create_registrar(&realm, &realm_authority, payer)
         .await;
+    context
+        .addin
+        .configure_voting_mint(
+            &registrar,
+            &realm_authority,
+            payer,
+            0,
+            &context.mints[0],
+            10,
+            0.0,
+            0.0,
+            1,
+            None,
+        )
+        .await;
     let mngo_voting_mint = context
         .addin
         .configure_voting_mint(


### PR DESCRIPTION
Previously the configure_voting_mint() instruction could only be run
once per index. Now it's allowed to call it again to change a mint's
parameters.

This will directly be useful for Mango, which will likely start out
configuring the MNGO voting mint without lockup vote scaling and then
later enable it, when the ui is ready.