### PR TITLE
Fix underflow problem in locked voting power computation

### DIFF
--- a/programs/voter-stake-registry/src/error.rs
+++ b/programs/voter-stake-registry/src/error.rs
@@ -70,4 +70,8 @@ pub enum ErrorCode {
     InvalidLockupKind,
     #[msg("")]
     InvalidChangeToClawbackDepositEntry,
+    #[msg("")]
+    InternalErrorBadLockupVoteWeight,
+    #[msg("")]
+    DepositStartTooFarInFuture,
 }

--- a/programs/voter-stake-registry/src/events/mod.rs
+++ b/programs/voter-stake-registry/src/events/mod.rs
@@ -1,12 +1,13 @@
 use anchor_lang::prelude::*;
 
 #[event]
+#[derive(Debug)]
 pub struct VoterInfo {
     pub voting_power: u64,
     pub voting_power_deposit_only: u64,
 }
 
-#[derive(AnchorSerialize, AnchorDeserialize)]
+#[derive(AnchorSerialize, AnchorDeserialize, Debug)]
 pub struct VestingInfo {
     /// Amount of tokens vested each period
     pub rate: u64,
@@ -14,7 +15,7 @@ pub struct VestingInfo {
     pub next_timestamp: u64,
 }
 
-#[derive(AnchorSerialize, AnchorDeserialize)]
+#[derive(AnchorSerialize, AnchorDeserialize, Debug)]
 pub struct LockingInfo {
     /// Amount of locked tokens
     pub amount: u64,
@@ -25,6 +26,7 @@ pub struct LockingInfo {
 }
 
 #[event]
+#[derive(Debug)]
 pub struct DepositEntryInfo {
     pub deposit_entry_index: u8,
     pub voting_mint_config_index: u8,

--- a/programs/voter-stake-registry/src/instructions/clawback.rs
+++ b/programs/voter-stake-registry/src/instructions/clawback.rs
@@ -85,9 +85,9 @@ pub fn clawback(ctx: Context<Clawback>, deposit_entry_index: u8) -> Result<()> {
         deposit_entry.amount_deposited_native -= locked_amount;
 
         // Now that all locked funds are withdrawn, end the lockup
+        let curr_ts = registrar.clock_unix_timestamp();
         deposit_entry.amount_initially_locked_native = 0;
-        deposit_entry.lockup =
-            Lockup::new_from_periods(LockupKind::None, registrar.clock_unix_timestamp(), 0)?;
+        deposit_entry.lockup = Lockup::new_from_periods(LockupKind::None, curr_ts, curr_ts, 0)?;
         deposit_entry.allow_clawback = false;
         locked_amount
     };

--- a/programs/voter-stake-registry/src/instructions/create_deposit_entry.rs
+++ b/programs/voter-stake-registry/src/instructions/create_deposit_entry.rs
@@ -47,7 +47,7 @@ pub struct CreateDepositEntry<'info> {
 ///
 /// - `deposit_entry_index`: deposit entry to use
 /// - `kind`: Type of lockup to use.
-/// - `start_ts`: Start timestamp, defaults to current clock.
+/// - `start_ts`: Start timestamp in seconds, defaults to current clock.
 ///    The lockup will end after `start + periods * period_secs()`.
 ///
 ///    Note that tokens will already be locked before start_ts, it only defines
@@ -79,10 +79,11 @@ pub fn create_deposit_entry(
     let d_entry = &mut voter.deposits[deposit_entry_index as usize];
     require!(!d_entry.is_used, UnusedDepositEntryIndex);
 
+    let curr_ts = registrar.clock_unix_timestamp();
     let start_ts = if let Some(v) = start_ts {
         i64::try_from(v).unwrap()
     } else {
-        registrar.clock_unix_timestamp()
+        curr_ts
     };
 
     *d_entry = DepositEntry::default();
@@ -91,7 +92,7 @@ pub fn create_deposit_entry(
     d_entry.amount_deposited_native = 0;
     d_entry.amount_initially_locked_native = 0;
     d_entry.allow_clawback = allow_clawback;
-    d_entry.lockup = Lockup::new_from_periods(kind, start_ts, periods)?;
+    d_entry.lockup = Lockup::new_from_periods(kind, curr_ts, start_ts, periods)?;
 
     Ok(())
 }

--- a/programs/voter-stake-registry/src/instructions/grant.rs
+++ b/programs/voter-stake-registry/src/instructions/grant.rs
@@ -153,10 +153,11 @@ pub fn grant(
         .ok_or(ErrorCode::DepositEntryFull)?;
     let d_entry = &mut voter.deposits[free_entry_idx];
 
+    let curr_ts = registrar.clock_unix_timestamp();
     let start_ts = if let Some(v) = start_ts {
         i64::try_from(v).unwrap()
     } else {
-        registrar.clock_unix_timestamp()
+        curr_ts
     };
 
     // Set up a deposit.
@@ -164,7 +165,7 @@ pub fn grant(
     d_entry.is_used = true;
     d_entry.voting_mint_config_idx = mint_idx as u8;
     d_entry.allow_clawback = allow_clawback;
-    d_entry.lockup = Lockup::new_from_periods(kind, start_ts, periods)?;
+    d_entry.lockup = Lockup::new_from_periods(kind, curr_ts, start_ts, periods)?;
 
     // Deposit tokens, locking them all.
     token::transfer(ctx.accounts.transfer_ctx(), amount)?;

--- a/programs/voter-stake-registry/src/instructions/log_voter_info.rs
+++ b/programs/voter-stake-registry/src/instructions/log_voter_info.rs
@@ -53,7 +53,10 @@ pub fn log_voter_info(ctx: Context<LogVoterInfo>, deposit_entry_begin: u8) -> Re
             amount: deposit.amount_locked(curr_ts),
             end_timestamp: (lockup.kind != LockupKind::Constant).then(|| end_ts),
             vesting: lockup.kind.is_vesting().then(|| VestingInfo {
-                rate: deposit.amount_initially_locked_native / periods_total,
+                rate: deposit
+                    .amount_initially_locked_native
+                    .checked_div(periods_total)
+                    .unwrap(),
                 next_timestamp: end_ts.saturating_sub(
                     periods_left
                         .saturating_sub(1)

--- a/programs/voter-stake-registry/src/instructions/log_voter_info.rs
+++ b/programs/voter-stake-registry/src/instructions/log_voter_info.rs
@@ -54,7 +54,12 @@ pub fn log_voter_info(ctx: Context<LogVoterInfo>, deposit_entry_begin: u8) -> Re
             end_timestamp: (lockup.kind != LockupKind::Constant).then(|| end_ts),
             vesting: lockup.kind.is_vesting().then(|| VestingInfo {
                 rate: deposit.amount_initially_locked_native / periods_total,
-                next_timestamp: end_ts - (periods_left - 1) * lockup.kind.period_secs(),
+                next_timestamp: end_ts.saturating_sub(
+                    periods_left
+                        .saturating_sub(1)
+                        .checked_mul(lockup.kind.period_secs())
+                        .unwrap(),
+                ),
             }),
         });
 

--- a/programs/voter-stake-registry/src/instructions/reset_lockup.rs
+++ b/programs/voter-stake-registry/src/instructions/reset_lockup.rs
@@ -50,7 +50,7 @@ pub fn reset_lockup(
     // Change the deposit entry.
     let d_entry = voter.active_deposit_mut(deposit_entry_index)?;
     d_entry.amount_initially_locked_native = d_entry.amount_deposited_native;
-    d_entry.lockup = Lockup::new_from_periods(kind, curr_ts, periods)?;
+    d_entry.lockup = Lockup::new_from_periods(kind, curr_ts, curr_ts, periods)?;
 
     Ok(())
 }

--- a/programs/voter-stake-registry/src/state/deposit_entry.rs
+++ b/programs/voter-stake-registry/src/state/deposit_entry.rs
@@ -232,7 +232,8 @@ impl DepositEntry {
             .saturating_sub(secs_to_closest_cliff)
             .checked_add(period_secs)
             .unwrap())
-            / period_secs;
+        .checked_div(period_secs)
+        .unwrap();
         let q = min(lockup_saturation_periods, periods_left);
         let r = periods_left.saturating_sub(q);
 

--- a/programs/voter-stake-registry/src/state/deposit_entry.rs
+++ b/programs/voter-stake-registry/src/state/deposit_entry.rs
@@ -342,7 +342,10 @@ impl DepositEntry {
             vested_amount <= self.amount_initially_locked_native,
             InternalProgramError
         );
-        self.amount_initially_locked_native -= vested_amount;
+        self.amount_initially_locked_native = self
+            .amount_initially_locked_native
+            .checked_sub(vested_amount)
+            .unwrap();
         self.lockup.remove_past_periods(curr_ts)?;
         require!(self.vested(curr_ts)? == 0, InternalProgramError);
         Ok(())

--- a/programs/voter-stake-registry/src/state/lockup.rs
+++ b/programs/voter-stake-registry/src/state/lockup.rs
@@ -117,7 +117,8 @@ impl Lockup {
             .seconds_left(curr_ts)
             .checked_add(period_secs.saturating_sub(1))
             .unwrap()
-            / period_secs)
+            .checked_div(period_secs)
+            .unwrap())
     }
 
     /// Returns the current period in the vesting schedule.
@@ -138,7 +139,7 @@ impl Lockup {
         let lockup_secs = self.seconds_left(self.start_ts);
         require!(lockup_secs % period_secs == 0, InvalidLockupPeriod);
 
-        Ok(lockup_secs / period_secs)
+        Ok(lockup_secs.checked_div(period_secs).unwrap())
     }
 
     /// Remove the vesting periods that are now in the past.

--- a/programs/voter-stake-registry/src/state/lockup.rs
+++ b/programs/voter-stake-registry/src/state/lockup.rs
@@ -113,7 +113,11 @@ impl Lockup {
         if curr_ts < self.start_ts {
             return self.periods_total();
         }
-        Ok((self.seconds_left(curr_ts) + period_secs - 1) / period_secs)
+        Ok(self
+            .seconds_left(curr_ts)
+            .checked_add(period_secs.saturating_sub(1))
+            .unwrap()
+            / period_secs)
     }
 
     /// Returns the current period in the vesting schedule.

--- a/programs/voter-stake-registry/src/state/lockup.rs
+++ b/programs/voter-stake-registry/src/state/lockup.rs
@@ -33,10 +33,10 @@ pub struct Lockup {
     ///
     /// Similarly vote power computations don't care about start_ts and always
     /// assume the full interval from now to end_ts.
-    start_ts: i64,
+    pub(crate) start_ts: i64,
 
     /// End of the lockup.
-    end_ts: i64,
+    pub(crate) end_ts: i64,
 
     /// Type of lockup.
     pub kind: LockupKind,

--- a/programs/voter-stake-registry/src/state/registrar.rs
+++ b/programs/voter-stake-registry/src/state/registrar.rs
@@ -26,7 +26,11 @@ const_assert!(std::mem::size_of::<Registrar>() == 5 * 32 + 4 * 120 + 8 + 1 + 31)
 
 impl Registrar {
     pub fn clock_unix_timestamp(&self) -> i64 {
-        Clock::get().unwrap().unix_timestamp + self.time_offset
+        Clock::get()
+            .unwrap()
+            .unix_timestamp
+            .checked_add(self.time_offset)
+            .unwrap()
     }
 
     pub fn voting_mint_config_index(&self, mint: Pubkey) -> Result<usize> {

--- a/programs/voter-stake-registry/tests/test_log_voter_info.rs
+++ b/programs/voter-stake-registry/tests/test_log_voter_info.rs
@@ -46,8 +46,6 @@ async fn test_print_event() -> Result<(), TransportError> {
         .ok_or(())
     );
 
-    assert_eq!(1, 2);
-
     Ok(())
 }
 

--- a/programs/voter-stake-registry/tests/test_log_voter_info.rs
+++ b/programs/voter-stake-registry/tests/test_log_voter_info.rs
@@ -16,6 +16,43 @@ fn deserialize_event<T: anchor_lang::Event>(event: &str) -> Option<T> {
 
 #[allow(unaligned_references)]
 #[tokio::test]
+async fn test_print_event() -> Result<(), TransportError> {
+    println!(
+        "{:?}",
+        deserialize_event::<voter_stake_registry::events::DepositEntryInfo>(
+            "LP4gbyknBZQAABhzAQAAAAAAGHMBAAAAAAAYcwEAAAAAAAEAAAAAAAAAAAGK6hx3fgEAAAA="
+        )
+        .ok_or(())
+    );
+    println!(
+        "{:?}",
+        deserialize_event::<voter_stake_registry::events::DepositEntryInfo>(
+            "LP4gbyknBZQBAAAAAAAAAAAAoIYBAAAAAABQwwAAAAAAAAFQwwAAAAAAAAFSl5iAfgEAAAA="
+        )
+        .ok_or(())
+    );
+    println!(
+        "{:?}",
+        deserialize_event::<voter_stake_registry::events::DepositEntryInfo>(
+            "LP4gbyknBZQCAAAAAAAAAAAARjI0BgAAAAAQJwAAAAAAAAEQJwAAAAAAAAGLPXx3fgEAAAEQJwAAAAAAAIs9fHd+AQAA"
+        )
+        .ok_or(())
+    );
+    println!(
+        "{:?}",
+        deserialize_event::<voter_stake_registry::events::DepositEntryInfo>(
+            "LP4gbyknBZQDAAAAAAAAAAAACFIAAAAAAACYOgAAAAAAAAGYOgAAAAAAAAAA"
+        )
+        .ok_or(())
+    );
+
+    assert_eq!(1, 2);
+
+    Ok(())
+}
+
+#[allow(unaligned_references)]
+#[tokio::test]
 async fn test_log_voter_info() -> Result<(), TransportError> {
     let context = TestContext::new().await;
     let addin = &context.addin;


### PR DESCRIPTION
- Fix the underflow itself
- Disallow lockups that start more than 100 years in the future
- Error if the lockup-scaled voting power is bigger than the maximum
  lockup voting power
- Address all soteria-reported math issues, just to be safe