### PR TITLE
Grant: Allow the voter authority to grant itself

### DIFF
--- a/programs/voter-stake-registry/src/instructions/grant.rs
+++ b/programs/voter-stake-registry/src/instructions/grant.rs
@@ -53,14 +53,20 @@ pub struct Grant<'info> {
 
     #[account(
         mut,
-        constraint = deposit_token.owner == authority.key(),
+        constraint = deposit_token.owner == token_authority.key(),
         constraint = deposit_token.mint == deposit_mint.key(),
     )]
     pub deposit_token: Box<Account<'info, TokenAccount>>,
 
-    // Verification inline in instruction
-    pub authority: Signer<'info>,
+    /// Authority for transfering tokens away from deposit_token
+    pub token_authority: Signer<'info>,
 
+    /// Authority for making a grant to this voter account
+    ///
+    /// Verification inline in instruction
+    pub grant_authority: Signer<'info>,
+
+    /// Rent payer if a new account is to be created
     #[account(mut)]
     pub payer: Signer<'info>,
 
@@ -78,7 +84,7 @@ impl<'info> Grant<'info> {
         let accounts = token::Transfer {
             from: self.deposit_token.to_account_info(),
             to: self.vault.to_account_info(),
-            authority: self.authority.to_account_info(),
+            authority: self.token_authority.to_account_info(),
         };
         CpiContext::new(program, accounts)
     }
@@ -115,9 +121,14 @@ pub fn grant(
     let mint_idx = registrar.voting_mint_config_index(ctx.accounts.deposit_token.mint)?;
     let mint_config = &registrar.voting_mints[mint_idx];
 
-    let authority = ctx.accounts.authority.key();
+    // The grant instruction creates a new deposit entry for the target voter. This is a
+    // limited resource. If anyone could call "grant" then it could be used for denial of
+    // service by filling all deposit entries with tiny amounts and long lockup times.
+    let grant_authority = ctx.accounts.grant_authority.key();
     require!(
-        authority == registrar.realm_authority || authority == mint_config.grant_authority,
+        grant_authority == registrar.realm_authority
+            || grant_authority == mint_config.grant_authority
+            || grant_authority == voter_authority,
         InvalidAuthority
     );
 

--- a/programs/voter-stake-registry/tests/program_test/addin.rs
+++ b/programs/voter-stake-registry/tests/program_test/addin.rs
@@ -326,7 +326,8 @@ impl AddinCookie {
         allow_clawback: bool,
         amount: u64,
         deposit_token: Pubkey,
-        authority: &Keypair,
+        token_authority: &Keypair,
+        grant_authority: &Keypair,
     ) -> std::result::Result<VoterCookie, TransportError> {
         let (voter, voter_bump) = Pubkey::find_program_address(
             &[
@@ -370,8 +371,9 @@ impl AddinCookie {
                 voter_weight_record,
                 vault,
                 deposit_token,
-                authority: authority.pubkey(),
-                payer: authority.pubkey(),
+                token_authority: token_authority.pubkey(),
+                grant_authority: grant_authority.pubkey(),
+                payer: token_authority.pubkey(),
                 deposit_mint: voting_mint.mint.pubkey.unwrap(),
                 system_program: solana_sdk::system_program::id(),
                 token_program: spl_token::id(),
@@ -388,10 +390,11 @@ impl AddinCookie {
         }];
 
         // clone the secrets
-        let signer1 = Keypair::from_base58_string(&authority.to_base58_string());
+        let signer1 = Keypair::from_base58_string(&grant_authority.to_base58_string());
+        let signer2 = Keypair::from_base58_string(&token_authority.to_base58_string());
 
         self.solana
-            .process_transaction(&instructions, Some(&[&signer1]))
+            .process_transaction(&instructions, Some(&[&signer1, &signer2]))
             .await?;
 
         Ok(voter_cookie)

--- a/programs/voter-stake-registry/tests/test_grants.rs
+++ b/programs/voter-stake-registry/tests/test_grants.rs
@@ -86,6 +86,7 @@ async fn test_grants() -> Result<(), TransportError> {
             12000,
             grant_funds,
             &grant_authority,
+            &realm_authority,
         )
         .await
         .unwrap();
@@ -102,6 +103,7 @@ async fn test_grants() -> Result<(), TransportError> {
             true,
             24000,
             grant_funds,
+            &grant_authority,
             &grant_authority,
         )
         .await
@@ -131,6 +133,7 @@ async fn test_grants() -> Result<(), TransportError> {
     assert_eq!(deposit.lockup.periods_total().unwrap(), 12);
 
     // grant funds with a start time in the past
+    // by the voter authority itself
     context.solana.advance_clock_by_slots(2).await;
     let now = context.solana.get_clock().await.unix_timestamp as u64;
     let start = now - LockupKind::Monthly.period_secs() * 2 - 60;
@@ -146,6 +149,7 @@ async fn test_grants() -> Result<(), TransportError> {
             12000,
             grant_funds,
             &grant_authority,
+            &voter_authority,
         )
         .await
         .unwrap();


### PR DESCRIPTION
This is done to allow governance proposals to grant to a voter from
arbitrary token accounts, as long as it's the voter themselves who
executes the proposal once the vote has succeeded.