### PR TITLE
Add function to compute the guaranteed locked vote power bonus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1985,9 +1985,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/programs/voter-stake-registry/src/error.rs
+++ b/programs/voter-stake-registry/src/error.rs
@@ -113,4 +113,7 @@ pub enum ErrorCode {
     // 6036 / 0x1794
     #[msg("")]
     VaultTokenNonZero,
+    // 6037 / 0x1795
+    #[msg("")]
+    InvalidTimestampArguments,
 }


### PR DESCRIPTION
This is useful for other programs that may want to make decisions purely
based on the amount of weight generated from guaranteed-to-be-locked
tokens at a specific time.