### PR TITLE
Added the required CHECK docs for Anchor

### DIFF
--- a/programs/voter-stake-registry/src/instructions/close_voter.rs
+++ b/programs/voter-stake-registry/src/instructions/close_voter.rs
@@ -27,6 +27,7 @@ pub struct CloseVoter<'info> {
     pub voter_authority: Signer<'info>,
 
     #[account(mut)]
+    /// CHECK: Destination may be any address.
     pub sol_destination: UncheckedAccount<'info>,
 
     pub token_program: Program<'info, Token>,

--- a/programs/voter-stake-registry/src/instructions/create_registrar.rs
+++ b/programs/voter-stake-registry/src/instructions/create_registrar.rs
@@ -20,12 +20,13 @@ pub struct CreateRegistrar<'info> {
 
     /// An spl-governance realm
     ///
-    /// realm is validated in the instruction:
+    /// CHECK: realm is validated in the instruction:
     /// - realm is owned by the governance_program_id
     /// - realm_governing_token_mint must be the community or council mint
     /// - realm_authority is realm.authority
     pub realm: UncheckedAccount<'info>,
 
+    /// CHECK: May be any instance of spl-governance
     /// The program id of the spl-governance program the realm belongs to.
     pub governance_program_id: UncheckedAccount<'info>,
     /// Either the realm community mint or the council mint.

--- a/programs/voter-stake-registry/src/instructions/create_voter.rs
+++ b/programs/voter-stake-registry/src/instructions/create_voter.rs
@@ -39,6 +39,7 @@ pub struct CreateVoter<'info> {
     pub system_program: Program<'info, System>,
     pub rent: Sysvar<'info, Rent>,
 
+    /// CHECK: Address constraint is set
     #[account(address = tx_instructions::ID)]
     pub instructions: UncheckedAccount<'info>,
 }

--- a/programs/voter-stake-registry/src/instructions/grant.rs
+++ b/programs/voter-stake-registry/src/instructions/grant.rs
@@ -21,6 +21,7 @@ pub struct Grant<'info> {
 
     /// The account of the grantee / the address controlling the voter
     /// that the grant is going to.
+    /// CHECK: May be any address
     pub voter_authority: UncheckedAccount<'info>,
 
     /// The voter weight record is the account that will be shown to spl-governance

--- a/programs/voter-stake-registry/src/instructions/update_max_vote_weight.rs
+++ b/programs/voter-stake-registry/src/instructions/update_max_vote_weight.rs
@@ -7,6 +7,7 @@ use anchor_lang::prelude::*;
 pub struct UpdateMaxVoteWeight<'info> {
     pub registrar: AccountLoader<'info, Registrar>,
     // TODO: SPL governance has not yet implemented this.
+    /// CHECK: TODO. Will be implemented when max_vote_weight_record is rolled out.
     pub max_vote_weight_record: UncheckedAccount<'info>,
 }
 

--- a/programs/voter-stake-registry/src/instructions/withdraw.rs
+++ b/programs/voter-stake-registry/src/instructions/withdraw.rs
@@ -23,7 +23,7 @@ pub struct Withdraw<'info> {
     /// to be able to forbid withdraws while the voter is engaged with
     /// a vote or has an open proposal.
     ///
-    /// token_owner_record is validated in the instruction:
+    /// CHECK: token_owner_record is validated in the instruction:
     /// - owned by registrar.governance_program_id
     /// - for the registrar.realm
     /// - for the registrar.realm_governing_token_mint


### PR DESCRIPTION
Anchor now requires that all `AccountInfo`s and `UncheckedAccount`s have a `/// CHECK` annotation. This PR adds them so that this codebase may build with Anchor 24.2.